### PR TITLE
#301 Don't justify text in mobile browser portrait

### DIFF
--- a/src/components/commentary/Commentary.js
+++ b/src/components/commentary/Commentary.js
@@ -47,7 +47,6 @@ const useStyles = makeStyles((theme) => ({
     paddingTop: 20,
     top: 135,
     bottom: 0,
-    textAlign: "justify",
     color: "#464545",
     fontFamily: "Roboto,Noto Sans",
     overflow: "scroll",
@@ -80,6 +79,9 @@ const useStyles = makeStyles((theme) => ({
       marginLeft: 30,
       maxWidth: "70%",
       margin: "30px 0px",
+    },
+    [theme.breakpoints.up("sm")]: {
+      textAlign: "justify",
     },
     [theme.breakpoints.down("sm")]: {
       top: (props) => (props.screenView === "single" ? 122 : 62),

--- a/src/components/dictionary/Dictionary.js
+++ b/src/components/dictionary/Dictionary.js
@@ -43,7 +43,6 @@ const useStyles = makeStyles((theme) => ({
     padding: "20px 20px 20px 0",
     top: 135,
     bottom: 0,
-    textAlign: "justify",
     color: "#464545",
     fontFamily: "Roboto,Noto Sans",
     overflow: "scroll",
@@ -70,6 +69,9 @@ const useStyles = makeStyles((theme) => ({
     "&::-webkit-scrollbar-thumb": {
       backgroundColor: "rgba(0,0,0,.4)",
       outline: "1px solid slategrey",
+    },
+    [theme.breakpoints.up("sm")]: {
+      textAlign: "justify",
     },
     [theme.breakpoints.down("sm")]: {
       top: 120,

--- a/src/components/read/Bible.js
+++ b/src/components/read/Bible.js
@@ -112,13 +112,15 @@ const useStyles = makeStyles((theme) => ({
   text: {
     paddingBottom: 30,
     marginBottom: 20,
-    textAlign: "justify",
     [`@media print`]: {
       fontSize: "1.2rem",
     },
     maxWidth: "1366px",
     [theme.breakpoints.up("md")]: {
       boxShadow: "0 2px 6px 0 hsl(0deg 0% 47% / 60%)",
+    },
+    [theme.breakpoints.up("sm")]: {
+      textAlign: "justify",
     },
     [theme.breakpoints.down("sm")]: {
       marginBottom: (props) =>


### PR DESCRIPTION
#301 Don't justify text in mobile browser portrait view as it creates space between word in a narrow screen