### PR TITLE
Mobile browser date format for Reading plan #376

### DIFF
--- a/src/components/readingplan/ReadingPlan.js
+++ b/src/components/readingplan/ReadingPlan.js
@@ -148,6 +148,10 @@ const useStyles = makeStyles((theme) => ({
       top: 0,
     },
   },
+  date: {
+    textTransform: "capitalize",
+    backgroundColor: "#fff",
+  },
 }));
 
 const ReadingPlan = (props) => {
@@ -199,6 +203,17 @@ const ReadingPlan = (props) => {
     }
   };
 
+  const CustomInput = React.forwardRef(({ value, onClick }, ref) => (
+    <Button
+      aria-haspopup="true"
+      variant="contained"
+      onClick={onClick}
+      ref={ref}
+      classes={{ root: classes.date }}
+    >
+      {value}
+    </Button>
+  ));
   const API = useMemo(
     () => axios.create({ baseURL: process.env.REACT_APP_BIBLE_PLANS_URL }),
     []
@@ -254,6 +269,12 @@ const ReadingPlan = (props) => {
                   selected={selectedDate}
                   onChange={(date) => setSelectedDate(date)}
                   withPortal
+                  todayButton="Today"
+                  dateFormat="dd MMM"
+                  showMonthDropdown
+                  minDate={new Date(new Date().getFullYear(), 0, 1)}
+                  maxDate={new Date(new Date().getFullYear(), 11, 31)}
+                  customInput={<CustomInput />}
                 />
               ) : null}
             </div>


### PR DESCRIPTION
Mobile browser change date format for Reading plan #376

1. Put mobile date format as 'dd MMM' i.e. '29 Jun'
2. Put custom input button similar to book drop down
3. Put min date as 1 Jan of current year and max date as 31 Dec of current year
4. Added today button at the bottom of date picker to go back to today's reading plan
5. Added month drop down to switch between months