### PR TITLE
Search passage input box hiding icons - bug fixed

### DIFF
--- a/src/components/read/TopBar.js
+++ b/src/components/read/TopBar.js
@@ -282,7 +282,7 @@ const TopBar = (props) => {
             ? ""
             : StoriesButton()}
           {path.startsWith("/read") ? searchBox() : ""}
-          {hideIcons ? (
+          {mobileView && hideIcons ? (
             ""
           ) : (
             <>


### PR DESCRIPTION
Bug fixed for the issue Search passage input box hiding icons in Topbar #453 