### PR TITLE
Show bible video if bible not present for lang#400

### DIFF
--- a/src/components/common/utility.js
+++ b/src/components/common/utility.js
@@ -240,7 +240,9 @@ export const capitalize = (string) => {
 export const getShortBook = (books, lang, bookCode) => {
   if (books) {
     const id = books[lang]?.findIndex((x) => x?.book_code === bookCode);
-    return books[lang][id]?.short;
+    if (id !== undefined) {
+      return books[lang][id]?.short;
+    }
   }
 };
 const checkValidChapter = (bookCode, chapter) => {


### PR DESCRIPTION
Show bible videos if bible is not present for language #400

- For this issue, I have checked these 6 minority languages ( Churahi, Gaddi, Kangri, Pahari Kullu, Mandeali andPahari Mahasu)
- If we select **Luke** from Book drop down and select any minority language that I mentioned above, then we will get videos.
- If we select other books except Luke, then we will get a warning message.